### PR TITLE
CLI updates

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "starwind",
-	"version": "1.0.2",
+	"version": "1.1.0",
 	"description": "Add beautifully designed components to your Astro applications",
 	"publishConfig": {
 		"access": "public"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,7 +48,7 @@
 	},
 	"dependencies": {
 		"@clack/prompts": "^0.9.1",
-		"@starwind-ui/core": "^1.0.0",
+		"@starwind-ui/core": "1.0.0",
 		"chalk": "^5.4.1",
 		"commander": "^13.0.0",
 		"execa": "^9.5.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,10 +2,6 @@
 	"name": "starwind",
 	"version": "1.1.0-next.1",
 	"description": "Add beautifully designed components to your Astro applications",
-	"publishConfig": {
-		"access": "public",
-		"branches": ["main", "next"]
-	},
 	"license": "MIT",
 	"author": {
 		"name": "webreaper",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,9 +1,10 @@
 {
 	"name": "starwind",
-	"version": "1.1.0",
+	"version": "1.1.0-next.1",
 	"description": "Add beautifully designed components to your Astro applications",
 	"publishConfig": {
-		"access": "public"
+		"access": "public",
+		"branches": ["main", "next"]
 	},
 	"license": "MIT",
 	"author": {

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -103,16 +103,17 @@ export async function add(components?: string[], options?: { all?: boolean }) {
 			return process.exit(0);
 		}
 
-		const confirmed = await p.confirm({
-			message: `Install ${componentsToInstall
-				.map((comp) => highlighter.info(comp))
-				.join(", ")} ${componentsToInstall.length > 1 ? "components" : "component"}?`,
-		});
+		// confirm installation
+		// const confirmed = await p.confirm({
+		// 	message: `Install ${componentsToInstall
+		// 		.map((comp) => highlighter.info(comp))
+		// 		.join(", ")} ${componentsToInstall.length > 1 ? "components" : "component"}?`,
+		// });
 
-		if (!confirmed || p.isCancel(confirmed)) {
-			p.cancel("Operation cancelled");
-			return process.exit(0);
-		}
+		// if (!confirmed || p.isCancel(confirmed)) {
+		// 	p.cancel("Operation cancelled");
+		// 	return process.exit(0);
+		// }
 
 		const results = {
 			installed: [] as InstallResult[],

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -86,16 +86,16 @@ export async function update(components?: string[], options?: { all?: boolean })
 		}
 
 		// Confirm update
-		const confirmed = await p.confirm({
-			message: `Check for updates to ${componentsToUpdate
-				.map((comp) => highlighter.info(comp))
-				.join(", ")} ${componentsToUpdate.length > 1 ? "components" : "component"}?`,
-		});
+		// const confirmed = await p.confirm({
+		// 	message: `Check for updates to ${componentsToUpdate
+		// 		.map((comp) => highlighter.info(comp))
+		// 		.join(", ")} ${componentsToUpdate.length > 1 ? "components" : "component"}?`,
+		// });
 
-		if (!confirmed || p.isCancel(confirmed)) {
-			p.cancel("Operation cancelled");
-			process.exit(0);
-		}
+		// if (!confirmed || p.isCancel(confirmed)) {
+		// 	p.cancel("Operation cancelled");
+		// 	process.exit(0);
+		// }
 
 		const results = {
 			updated: [] as UpdateResult[],

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -17,6 +17,7 @@ interface AliasConfig {
 }
 
 export interface StarwindConfig {
+	$schema: string;
 	tailwind: TailwindConfig;
 	// aliases: AliasConfig;
 	componentDir: string;
@@ -24,9 +25,10 @@ export interface StarwindConfig {
 }
 
 const defaultConfig: StarwindConfig = {
+	$schema: "https://starwind.dev/schema.json",
 	tailwind: {
 		css: "src/styles/starwind.css",
-		baseColor: "gray",
+		baseColor: "neutral",
 		cssVariables: true,
 	},
 	// aliases: {

--- a/packages/cli/src/utils/constants.ts
+++ b/packages/cli/src/utils/constants.ts
@@ -6,7 +6,7 @@ export const MIN_ASTRO_VERSION = "5.0.0";
 export const PATHS = {
 	STARWIND_CORE: "@starwind-ui/core",
 	STARWIND_CORE_COMPONENTS: "src/components",
-	STARWIND_CORE_REGISTRY: "registry.json",
+	STARWIND_COMPONENT_REGISTRY: "https://starwind.dev/registry.json",
 	LOCAL_CSS_FILE: "src/styles/starwind.css",
 	LOCAL_CONFIG_FILE: "starwind.config.json",
 	LOCAL_STYLES_DIR: "src/styles",

--- a/packages/cli/src/utils/registry.ts
+++ b/packages/cli/src/utils/registry.ts
@@ -1,5 +1,5 @@
-import { registry } from "@starwind-ui/core";
 import { z } from "zod";
+import { PATHS } from "./constants.js";
 
 const componentSchema = z.object({
 	name: z.string(),
@@ -10,22 +10,84 @@ const componentSchema = z.object({
 
 export type Component = z.infer<typeof componentSchema>;
 
-const registrySchema = z.array(componentSchema);
+// Schema for the root registry object
+const registryRootSchema = z.object({
+	$schema: z.string().optional(),
+	components: z.array(componentSchema),
+});
 
-export async function getRegistry(): Promise<Component[]> {
+// Cache for registry data - stores the promise of fetching to avoid multiple simultaneous requests
+const registryCache = new Map<string, Promise<any>>();
+
+/**
+ * Fetches the component registry from the remote server
+ * @param forceRefresh Whether to force a refresh of the cache
+ * @returns A promise that resolves to an array of Components
+ */
+export async function getRegistry(forceRefresh = false): Promise<Component[]> {
+	const cacheKey = PATHS.STARWIND_COMPONENT_REGISTRY;
+
+	// Return cached promise if available and refresh not forced
+	if (!forceRefresh && registryCache.has(cacheKey)) {
+		return registryCache.get(cacheKey)!;
+	}
+
+	// Create a new promise for the fetch operation
+	const fetchPromise = fetchRegistry();
+
+	// Cache the promise
+	registryCache.set(cacheKey, fetchPromise);
+
+	return fetchPromise;
+}
+
+/**
+ * Internal function to fetch the registry from the remote server
+ */
+async function fetchRegistry(): Promise<Component[]> {
 	try {
-		return registrySchema.parse(registry);
+		const response = await fetch(PATHS.STARWIND_COMPONENT_REGISTRY);
+
+		if (!response.ok) {
+			throw new Error(`Failed to fetch registry: ${response.status} ${response.statusText}`);
+		}
+
+		const data = await response.json();
+		const parsedRegistry = registryRootSchema.parse(data);
+
+		return parsedRegistry.components;
 	} catch (error) {
 		console.error("Failed to load registry:", error);
 		throw error;
 	}
 }
 
-export async function getComponent(name: string): Promise<Component | undefined> {
-	const registry = await getRegistry();
+/**
+ * Clear the registry cache
+ */
+export function clearRegistryCache(): void {
+	registryCache.clear();
+}
+
+/**
+ * Get a component by name from the registry
+ * @param name The name of the component to find
+ * @param forceRefresh Whether to force a refresh of the registry cache
+ * @returns The component or undefined if not found
+ */
+export async function getComponent(
+	name: string,
+	forceRefresh = false,
+): Promise<Component | undefined> {
+	const registry = await getRegistry(forceRefresh);
 	return registry.find((component) => component.name === name);
 }
 
-export async function getAllComponents(): Promise<Component[]> {
-	return getRegistry();
+/**
+ * Get all components from the registry
+ * @param forceRefresh Whether to force a refresh of the registry cache
+ * @returns All components in the registry
+ */
+export async function getAllComponents(forceRefresh = false): Promise<Component[]> {
+	return getRegistry(forceRefresh);
 }


### PR DESCRIPTION
- Add config file schema hosted at [starwind.dev/config-schema.json](https://starwind.dev/config-schema.json)
- Component registry now hosted at [https://starwind.dev/registry.json](https://starwind.dev/registry.json). Caching implemented to avoid extra fetches
- Remove extra user confirmation requirements in "add" and "update" commands
- Lock starwind-ui/core version in the CLI for better control